### PR TITLE
Add author display under pattern title

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -136,6 +136,18 @@
     [data-md-color-scheme="slate"] .pattern-source a {
         color: #63b3ed;
     }
+
+    /* Pattern authors styling */
+    .pattern-authors {
+        font-size: 0.9em;
+        color: #6c757d;
+        margin-bottom: 1.5rem;
+        font-style: italic;
+    }
+
+    [data-md-color-scheme="slate"] .pattern-authors {
+        color: #a0aec0;
+    }
   </style>
 {% endblock %}
 

--- a/overrides/partials/content.html
+++ b/overrides/partials/content.html
@@ -1,0 +1,13 @@
+{% if "\x3ch1" not in page.content %}
+  <h1>{{ page.title | d(config.site_name, true)}}</h1>
+{% endif %}
+
+{% if page.meta.authors %}
+  <div class="pattern-authors">
+    {% for author in page.meta.authors %}
+      <span>{{ author }}</span>{% if not loop.last %}, {% endif %}
+    {% endfor %}
+  </div>
+{% endif %}
+
+{{ page.content }}


### PR DESCRIPTION
## Summary
- Display `authors` field from pattern YAML front-matter under the title
- Authors appear in italic text below the pattern title
- Supports light and dark mode styling

## Test plan
- [ ] Build and preview site locally (`make site_preview`)
- [ ] Verify authors display under titles on pattern pages with `authors` field
- [ ] Verify no change on pages without `authors` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)