### PR TITLE
fix: broken mermaid in parallel tool execution

### DIFF
--- a/docs/patterns/parallel-tool-execution.md
+++ b/docs/patterns/parallel-tool-execution.md
@@ -34,7 +34,7 @@ flowchart TD
     A[Agent Requests Multiple Tools Simultaneously] --> B{Inspect Tool Types in Batch}
     B --> C{All Tools Read-Only?}
     C -- Yes --> D[Execute All Tools Concurrently]
-    C -- No --> E[Execute All Tools Sequentially (in order)]
+    C -- No --> E["Execute All Tools Sequentially (in order)"]
     D --> F[Collect & Order Results]
     E --> F
     F --> G[Return Aggregate Results to Agent]

--- a/patterns/parallel-tool-execution.md
+++ b/patterns/parallel-tool-execution.md
@@ -34,7 +34,7 @@ flowchart TD
     A[Agent Requests Multiple Tools Simultaneously] --> B{Inspect Tool Types in Batch}
     B --> C{All Tools Read-Only?}
     C -- Yes --> D[Execute All Tools Concurrently]
-    C -- No --> E[Execute All Tools Sequentially (in order)]
+    C -- No --> E["Execute All Tools Sequentially (in order)"]
     D --> F[Collect & Order Results]
     E --> F
     F --> G[Return Aggregate Results to Agent]


### PR DESCRIPTION
This PR fixes broken mermaid in https://agentic-patterns.com/patterns/parallel-tool-execution/

| Before | After |
|--------|-------|
| <img width="739" height="150" alt="image" src="https://github.com/user-attachments/assets/343ad498-99ad-4cf6-80ae-944814a6bbdd" /> | <img width="710" height="870" alt="image" src="https://github.com/user-attachments/assets/451916cb-4edb-44ef-98b4-f0e66c536b32" /> |
