### PR TITLE
chore: update Agent Governance Toolkit URLs to microsoft/ org

### DIFF
--- a/docs/patterns/zero-trust-agent-mesh.md
+++ b/docs/patterns/zero-trust-agent-mesh.md
@@ -56,5 +56,5 @@ sequenceDiagram
 
 - [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/publications/detail/sp/800-207/final)
 - [SPIFFE/SPIRE](https://spiffe.io/)
-- [AgentMesh (example implementation)](https://github.com/imran-siddique/agent-mesh)
+- [AgentMesh (example implementation)](https://github.com/microsoft/agent-governance-toolkit)
 - [A2A Protocol](https://github.com/a2aproject/A2A)

--- a/patterns/zero-trust-agent-mesh.md
+++ b/patterns/zero-trust-agent-mesh.md
@@ -69,5 +69,5 @@ sequenceDiagram
 - Beurer-Kellner et al. (2025). "Design Patterns for Securing LLM Agents against Prompt Injections" [arXiv:2506.08837](https://doi.org/10.48550/arXiv.2506.08837)
 - Greshake et al. (2023). "Not What You've Signed Up For: Compromising Real-World LLM-Integrated Applications" [arXiv:2302.12173](https://doi.org/10.48550/arXiv.2302.12173)
 - [SPIFFE/SPIRE](https://spiffe.io/)
-- [AgentMesh (example implementation)](https://github.com/imran-siddique/agent-mesh)
+- [AgentMesh (example implementation)](https://github.com/microsoft/agent-governance-toolkit)
 - [A2A Protocol](https://github.com/a2aproject/A2A)

--- a/research/soulbound-identity-verification-report.md
+++ b/research/soulbound-identity-verification-report.md
@@ -637,7 +637,7 @@ interface IERC5192 {
 #### 5. AgentMesh
 
 **Type**: Open Source Implementation
-**Repository**: https://github.com/imran-siddique/agent-mesh
+**Repository**: https://github.com/microsoft/agent-governance-toolkit
 **Status**: Open Source / Development
 **Based On**: NIST SP 800-207 (Zero Trust Architecture), SPIFFE/SPIRE concepts
 
@@ -664,7 +664,7 @@ interface IERC5192 {
 **Production Status**: Open source, reference implementation
 
 **Links**:
-- Repository: https://github.com/imran-siddique/agent-mesh
+- Repository: https://github.com/microsoft/agent-governance-toolkit
 
 ---
 

--- a/research/zero-trust-agent-mesh-report.md
+++ b/research/zero-trust-agent-mesh-report.md
@@ -242,7 +242,7 @@ Apply zero-trust principles to inter-agent communication:
 
 #### AgentMesh (Reference Implementation)
 
-**Repository:** https://github.com/imran-siddique/agent-mesh
+**Repository:** https://github.com/microsoft/agent-governance-toolkit
 **Status:** Development
 **Key Features:**
 ```python
@@ -697,7 +697,7 @@ Zero-Trust + Sub-Agent Spawning + Subject Hygiene
 ### Primary Sources
 - [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/publications/detail/sp/800-207/final)
 - [SPIFFE/SPIRE](https://spiffe.io/)
-- [AgentMesh Implementation](https://github.com/imran-siddique/agent-mesh)
+- [AgentMesh Implementation](https://github.com/microsoft/agent-governance-toolkit)
 - [A2A Protocol](https://github.com/a2aproject/A2A)
 
 ### Academic Papers


### PR DESCRIPTION
The Agent Governance Toolkit has moved to [microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit). This PR updates URLs to the new location.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 3 failed — [View all](https://hub.continue.dev/inbox/pr/nibzard/awesome-agentic-patterns/31?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->