### PR TITLE
Add Declarative Multi-Agent Topology Definition to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The tables below are auto‑generated from the `patterns/` folder.
 - [Continuous Autonomous Task Loop Pattern](patterns/continuous-autonomous-task-loop-pattern.md)
 - [Cross-Cycle Consensus Relay](patterns/cross-cycle-consensus-relay.md)
 - [Custom Sandboxed Background Agent](patterns/custom-sandboxed-background-agent.md)
+- [Declarative Multi-Agent Topology Definition](patterns/declarative-multi-agent-topology-definition.md)
 - [Discrete Phase Separation](patterns/discrete-phase-separation.md)
 - [Disposable Scaffolding Over Durable Features](patterns/disposable-scaffolding-over-durable-features.md)
 - [Distributed Execution with Cloud Workers](patterns/distributed-execution-cloud-workers.md)


### PR DESCRIPTION
## Summary

- The pattern file `patterns/declarative-multi-agent-topology-definition.md` was merged but not listed in the README
- Adds the entry to the **Orchestration & Control** section in alphabetical order, matching the existing format

## Test plan

- [ ] Verify the link resolves to the correct pattern file
- [ ] Verify alphabetical ordering is correct in the Orchestration & Control section

🤖 Generated with [Claude Code](https://claude.com/claude-code)