### PR TITLE
Add: agent-circuit-breaker

### DIFF
--- a/patterns/agent-circuit-breaker.md
+++ b/patterns/agent-circuit-breaker.md
@@ -4,7 +4,7 @@ status: emerging
 authors: ["Jeel Thummar (@jeelthummar)"]
 based_on: ["Michael Nygard (Release It!, 2007)", "Netflix Hystrix Team"]
 category: "Reliability & Eval"
-source: "https://martinfowler.com/bliki/CircuitBreaker.html"
+source: "https://github.com/Jeel3011/agent-circuit-breaker-impl"
 tags: [circuit-breaker, fault-tolerance, tool-reliability, graceful-degradation, resilience]
 summary: "Prevents agents from wasting tokens and time on repeatedly failing tools by tracking failure rates and temporarily disabling broken tool endpoints"
 maturity: "maturing"


### PR DESCRIPTION
# Pattern: Agent Circuit Breaker

This PR adds the **Agent Circuit Breaker** pattern to the Reliability & Eval category.

It addresses a fundamental failure mode in agent tool use: when a tool endpoint (API, database, external service) becomes degraded, simple retries result in a cascading waste of tokens and latency with zero progress. By porting the classic distributed systems circuit breaker pattern directly into the agent's tool execution layer, the agent can fast-fail broken tools, recover gracefully via half-open probes, and route to alternative fallbacks without getting stuck in infinite retry loops.

### Checklist
- [x] This is about a reusable pattern, not a launch post.
- [x] Problem, Solution, and Trade-offs are present and specific.
- [x] No marketing/CTA language in body or references section.
- [x] Source links are public and verifiable.
- [x] Validated locally via 

*(Note: While similar to failover-aware model fallback, this pattern specifically targets tool and environment failures rather than LLM provider outages.)*