### PR TITLE
Add pattern: Agentic Governance Rollout

### DIFF
--- a/patterns/agentic-governance-rollout.md
+++ b/patterns/agentic-governance-rollout.md
@@ -1,0 +1,68 @@
+---
+title: "Agentic Governance Rollout"
+status: emerging
+authors: ["Neeraj Patil (@neerazz)"]
+based_on: ["GenOps Framework (https://github.com/neerazz/genops-framework)"]
+category: "Security & Safety"
+source: "https://github.com/neerazz/genops-framework"
+tags: [governance, canary-rollout, risk-scoring, autonomy-gates, rollback, audit-trail, ci-cd, policy-as-code]
+---
+
+## Problem
+
+Autonomous agents are increasingly promoted from "assistant suggesting an action" to "system taking the action" — opening pull requests, deploying services, paying invoices, writing to production data stores. Each promotion increases blast radius. Teams have no principled way to decide *how much* autonomy a given agent version deserves, *when* it has earned more, and *how* to roll it back without an incident review.
+
+Three failure modes are common:
+
+1. A new agent version is deployed to 100% of traffic and immediately misbehaves on a class of inputs the test suite did not cover.
+2. A version drifts in subtle ways (slightly higher refund rates, slightly more aggressive code edits) that no single decision flags, but that compound across thousands of decisions.
+3. When something does go wrong, the post-incident audit cannot reconstruct *which policy was in force*, *which agent version made the call*, or *what risk score it was operating under*.
+
+Manual review of every agent action does not scale; turning the agent fully loose is unsafe.
+
+## Solution
+
+Treat each agent rollout the way mature platforms treat a service deploy: gate it on a signed policy, ramp it through a canary, compare it to a baseline, roll it back automatically on regression, and record everything in a tamper-evident log.
+
+Four components, deployed as middleware around the agent's decision/tool-call loop:
+
+1. **Risk-scored decision boundaries.** For every action the agent proposes, a scoring function returns a numeric risk score from features of the action (tool, parameters, target environment, dollar value, data sensitivity, reversibility). A signed governance policy defines bands — `auto`, `canary-only`, `human-approval`, `deny` — and the band, not the agent, decides what executes.
+
+2. **Canary rollout against a baseline.** A new agent version (`candidate`) handles a small, policy-defined share of eligible decisions; the previous version (`baseline`) handles the rest. Both run inside the same risk-scoring envelope. Outcome metrics (success rate, override rate, downstream incident rate, cost per decision) are compared with pre-registered thresholds. The candidate is promoted to higher traffic only when its bands meet or beat baseline.
+
+3. **Automatic rollback on policy violation.** A bounded set of conditions — risk-band breach, exceeded refund/spend ceiling, safety-classifier hit, sustained regression vs. baseline — flips the candidate's traffic share to zero without waiting for a human. The rollback itself is a governed action: it is signed, logged, and emits the same audit record any other decision would.
+
+4. **Immutable audit trail bound to a signed policy.** Every decision record stores `(agent_version, policy_hash, policy_signature, risk_score, band, baseline_or_candidate, outcome, rollback_marker)` in an append-only store. The policy is signed at publish time; the signature is checked at decision time and stored with the record, so any audit can answer "under what rules was this action allowed?" cryptographically.
+
+The pattern is intentionally framework-agnostic: it wraps the agent's tool-calling boundary and treats the agent as a black box that produces proposed actions.
+
+## How to use it
+
+- Start by enumerating the *actions* the agent can take and assigning each a risk feature vector. Risk scoring is more important than model choice.
+- Express the governance policy as code or declarative config, sign it, and version it independently of the agent. Treat policy changes the way you treat schema migrations.
+- Pick one high-volume, low-blast-radius action class (e.g. "open draft PR", "tag ticket") for the first canary. Do not start with payments or destructive ops.
+- Define the candidate-vs-baseline metrics *before* the rollout. Include at least one human-override metric — if reviewers reject the candidate's actions more often than the baseline's, that is a regression even if everything else looks fine.
+- Wire rollback into the same control plane as deploys, so the on-call rollback runbook is one path, not two.
+- Store the audit trail outside the agent's own environment (separate account, separate key). The agent must not be able to rewrite its own history.
+
+## Trade-offs
+
+- **Pros:**
+  - Decouples *what the agent can propose* from *what is allowed to execute*, which is the safety property that actually matters.
+  - Canary + baseline gives a quantitative promotion criterion instead of vibes.
+  - Automatic rollback bounds the worst case to the canary share, not the full fleet.
+  - Signed-policy audit trail satisfies regulator-style "show me the rule that was in force" questions and supports EU AI Act / SOC2 record-keeping.
+
+- **Cons / considerations:**
+  - Requires investment in a risk-scoring function; a bad scorer makes every other layer weaker.
+  - Canary comparison needs enough decision volume to detect regression with reasonable power; very low-traffic action classes are hard to govern this way.
+  - Signed-policy machinery adds operational surface area (keys, rotation, verification).
+  - The pattern presumes the agent's actions are observable and attributable; opaque downstream effects (e.g. an LLM-written file that breaks something three deploys later) still need separate detection.
+
+## Related Work
+
+- [GenOps Framework](https://github.com/neerazz/genops-framework) — Open-source reference implementation: risk-scored autonomy gates, canary controller, rollback, and signed audit trail for embedding generative-AI agents in CI/CD. MIT.
+- "GenOps: A Governance-First Framework for Embedding Generative AI Agents into CI/CD Pipelines," *Journal of Information Systems Engineering and Management*, 11(1s), 2026. DOI: [10.52783/jisem.v11i1s.14322](https://doi.org/10.52783/jisem.v11i1s.14322).
+- [Cryptographic Governance Audit Trail](cryptographic-governance-audit-trail.md) — Complementary pattern for tamper-evident per-action receipts; the audit-trail component here can be implemented on top of it.
+- [Hook-Based Safety Guard Rails for Autonomous Code Agents](hook-based-safety-guard-rails.md) — Complementary pattern for in-loop pre/post-tool checks; risk bands here can call those hooks as their enforcement primitive.
+- [Policy-Gated Tool Proxy](policy-gated-tool-proxy.md) — Related enforcement-point pattern for tool-call mediation.


### PR DESCRIPTION
Adds a new pattern under Security & Safety: **Agentic Governance Rollout**.

The pattern formalizes how to safely roll out autonomous AI agents into production by combining risk-scored decision boundaries, canary rollouts comparing new agent behavior against a baseline, automatic rollback on policy violations, and immutable audit trails linking every decision to a signed governance policy.

README entry is intentionally not modified — it lives inside the AUTO-GENERATED PATTERNS markers per CONTRIBUTING.md.

Reference implementation and full discussion: GenOps Framework (https://github.com/neerazz/genops-framework, MIT), published in JISEM 2026 (DOI [10.52783/jisem.v11i1s.14322](https://doi.org/10.52783/jisem.v11i1s.14322)).