### PR TITLE
Add: filesystem-mediated-host-delegation

### DIFF
--- a/patterns/filesystem-mediated-host-delegation.md
+++ b/patterns/filesystem-mediated-host-delegation.md
@@ -1,0 +1,142 @@
+---
+title: Filesystem-Mediated Host Delegation
+status: emerging
+authors: ["Abhinay Krupa (@abhinaykrupa)"]
+based_on: ["Maildir-style spool directories", "Claude Code / Cowork sandbox split"]
+category: "Tool Use & Environment"
+source: "https://github.com/abhinaykrupa/cowork-to-code-bridge"
+tags: [sandbox-escape, host-execution, async-rpc, idempotency, spool-directory, durability]
+---
+
+## Problem
+
+An agent that runs inside a sandbox — a container, a hosted runtime, a cloud
+workspace — is deliberately cut off from the developer's real machine. That
+isolation is correct for safety, but it puts the most valuable work out of
+reach: the toolchain, the local filesystem, git credentials, the Docker daemon,
+and the half-configured services that only exist on someone's laptop.
+
+The obvious fixes are worse than the problem:
+
+- **Open a port on the host.** Now the developer's machine listens on the
+  network for an agent to tell it what to run. This is the same shape as a
+  remote-access backdoor, and it fails immediately behind NAT or a corporate VPN.
+- **Hold a synchronous connection.** Sandboxes get suspended, hit request
+  timeouts, and are reaped. A 20-minute build outlives the caller, and when the
+  caller dies mid-flight the work is orphaned with no way to reclaim the result.
+- **Re-issue the call on reconnect.** Without a durable identity for the
+  request, a retry after a dropped connection re-runs a deploy or a migration
+  a second time.
+
+The underlying difficulty is that the two sides have *different lifetimes*. The
+sandbox is ephemeral and may vanish mid-task; the host is long-lived. Any
+mechanism that assumes both endpoints stay alive for the duration of the work
+will drop tasks.
+
+## Solution
+
+Move the coupling from a connection to a **shared directory**. Neither side
+talks to the other directly. Both sides only append to and read from a spool
+directory that is visible to each — a bind mount, a synced folder, a mounted
+volume.
+
+The directory holds three roles:
+
+- `queue/` — request files the sandbox writes
+- `results/` — completed result files the host writes
+- `inbox/` — messages travelling host → sandbox
+
+A host-side daemon watches `queue/`, executes what it finds against a whitelist
+of permitted operations, and writes the outcome to `results/` keyed by a task
+id. The sandbox writes a request, gets the id back immediately, and polls for
+that id whenever it happens to be alive.
+
+```pseudo
+// sandbox side — never blocks on the host
+task_id = write(queue/, {op, args, timeout, idempotency_key})
+...                                  // sandbox may be suspended here
+result  = read(results/task_id)      // returns pending | running | done
+
+// host side — a loop, not a server
+for request in watch(queue/):
+    if seen(request.idempotency_key): continue   // retries collapse
+    result = execute_if_whitelisted(request)
+    atomic_write(results/request.id, result)
+```
+
+```mermaid
+graph LR
+    A[Sandboxed agent] -->|writes request| Q[queue/]
+    Q --> D[Host daemon]
+    D -->|executes on real machine| H[Toolchain / git / Docker]
+    D -->|writes outcome| R[results/]
+    R -->|polled when alive| A
+```
+
+Three properties do the real work:
+
+1. **No listener.** The host opens no port and accepts no inbound connection.
+   Reachability comes from the shared mount, so NAT and VPNs are irrelevant.
+2. **Durability by default.** A request that has been written survives the
+   sandbox dying, the host rebooting, and the poller disappearing for an hour.
+   The result waits in a file until something reads it.
+3. **Idempotency keys make retries safe.** A caller that cannot tell whether its
+   request landed simply writes it again with the same key; the daemon
+   recognises the key and returns the existing result instead of re-executing.
+
+Polling must be a pure read with no side effects, so a nervous caller can check
+as often as it likes.
+
+## Evidence
+
+- **Evidence Grade:** `medium`
+- **Most Valuable Findings:**
+  - Spool directories are a long-proven durability mechanism (Maildir, mail
+    queues, CI artifact dirs); applying them to agent RPC inherits crash-safety
+    without inventing a protocol.
+  - Decoupling caller lifetime from work lifetime is what makes long host-side
+    tasks survivable — the same reason job queues beat synchronous RPC generally.
+- **Unverified / Unclear:** No published comparative benchmark of this approach
+  against tunnel- or socket-based host bridges. Polling latency versus a
+  filesystem-watch trigger is implementation-specific and unmeasured here.
+
+## How to use it
+
+Reach for this when **the agent and the work live in different trust or
+lifetime domains** and the work must happen on specific hardware:
+
+- Cloud or sandboxed agents that need to build, test, or run something locally
+- Agents whose runtime imposes a short request timeout but whose tasks do not
+- Any case where opening an inbound port on a developer machine is unacceptable
+
+Prerequisites: a directory both sides can reach, atomic file writes (write to a
+temp name, then rename), and a whitelist on the host defining what may run.
+
+Because the host executes real commands, pair the transport with a per-task
+safety envelope — a spend ceiling, a permission scope (read-only versus
+mutating), and optional human plan-approval before anything runs. The transport
+gives durability; it gives no safety on its own.
+
+## Trade-offs
+
+- **Pros:**
+  - Survives reboots, sandbox suspension, and caller death without losing work
+  - No inbound port, no tunnel, no NAT traversal
+  - Trivially debuggable and auditable — the protocol is files you can read
+  - Retries are safe when keyed
+- **Cons:**
+  - Polling adds latency; unsuitable for tight interactive loops
+  - Requires a shared mount, which not every sandbox offers
+  - The daemon holds real execution authority, so the whitelist and permission
+    scope become the security boundary
+  - Concurrent writers need atomic rename discipline or results interleave
+  - Spool directories grow and need reaping
+
+## References
+
+- [Maildir](https://cr.yp.to/proto/maildir.html) — the canonical crash-safe
+  spool-directory design this borrows from.
+- [LangGraph — Human-in-the-Loop](https://langchain-ai.github.io/langgraph/concepts/human_in_the_loop/)
+  — pausing and resuming long-running work across process lifetimes.
+- [cowork-to-code-bridge](https://github.com/abhinaykrupa/cowork-to-code-bridge)
+  — a working implementation, maintained by this pattern's author.

--- a/patterns/filesystem-mediated-host-delegation.md
+++ b/patterns/filesystem-mediated-host-delegation.md
@@ -18,9 +18,9 @@ and the half-configured services that only exist on someone's laptop.
 
 The obvious fixes are worse than the problem:
 
-- **Open a port on the host.** Now the developer's machine listens on the
-  network for an agent to tell it what to run. This is the same shape as a
-  remote-access backdoor, and it fails immediately behind NAT or a corporate VPN.
+- **Open a port on the host.** Now the developer's machine exposes another
+  network service that must be authenticated, authorized, and reachable through
+  NAT or a corporate VPN.
 - **Hold a synchronous connection.** Sandboxes get suspended, hit request
   timeouts, and are reaped. A 20-minute build outlives the caller, and when the
   caller dies mid-flight the work is orphaned with no way to reclaim the result.
@@ -35,10 +35,11 @@ will drop tasks.
 
 ## Solution
 
-Move the coupling from a connection to a **shared directory**. Neither side
-talks to the other directly. Both sides only append to and read from a spool
-directory that is visible to each — a bind mount, a synced folder, a mounted
-volume.
+Move the coupling from a connection to a **shared directory**. Both sides append
+to and read from a spool directory that is visible to each — a bind mount, a
+synced folder, or a mounted volume. The directory is still an inbound
+command-and-control channel, so it must be secured as deliberately as a network
+API even though the host exposes no listening socket.
 
 The directory holds three roles:
 
@@ -53,15 +54,28 @@ that id whenever it happens to be alive.
 
 ```pseudo
 // sandbox side — never blocks on the host
-task_id = write(queue/, {op, args, timeout, idempotency_key})
+key = stable_idempotency_key(op, args, caller_intent)
+atomic_write(queue/key, signed_request(op, typed_args, timeout, key))
 ...                                  // sandbox may be suspended here
-result  = read(results/task_id)      // returns pending | running | done
+result = read(results/key)           // returns pending | running | done | uncertain
 
-// host side — a loop, not a server
-for request in watch(queue/):
-    if seen(request.idempotency_key): continue   // retries collapse
-    result = execute_if_whitelisted(request)
-    atomic_write(results/request.id, result)
+// host side — atomic rename lets only one worker claim a request
+for request in claim_by_rename(queue/, running/):
+    verify_signature_schema_and_permissions(request)
+    key = request.idempotency_key
+    if exists(results/key):
+        continue                              // replay the durable result
+    ledger.record(key, "running")
+    result = execute_allowlisted_operation(request, idempotency_key=key)
+    atomic_write(results/key, result)
+    ledger.record(key, "done")
+
+// after a crash, never blindly repeat an operation with uncertain outcome
+for key in ledger.entries("running"):
+    if downstream_can_lookup_or_deduplicate(key):
+        reconcile_and_publish(key)
+    else:
+        ledger.record(key, "uncertain")       // require human reconciliation
 ```
 
 ```mermaid
@@ -75,14 +89,17 @@ graph LR
 
 Three properties do the real work:
 
-1. **No listener.** The host opens no port and accepts no inbound connection.
-   Reachability comes from the shared mount, so NAT and VPNs are irrelevant.
-2. **Durability by default.** A request that has been written survives the
-   sandbox dying, the host rebooting, and the poller disappearing for an hour.
-   The result waits in a file until something reads it.
-3. **Idempotency keys make retries safe.** A caller that cannot tell whether its
-   request landed simply writes it again with the same key; the daemon
-   recognises the key and returns the existing result instead of re-executing.
+1. **No network listener.** The host opens no port. Reachability comes from the
+   shared mount, so NAT and VPN traversal are not part of this protocol. Access
+   to the directory still grants authority to submit work.
+2. **Durable decoupling.** On persistent storage, an atomically written and
+   flushed request can outlive the sandbox or poller. Surviving a host reboot
+   additionally requires a durable spool and ledger; a temporary bind mount or
+   best-effort sync does not provide that guarantee.
+3. **Idempotency plus reconciliation makes retries safe.** Completed requests
+   replay their stored result. Requests whose outcome was uncertain at a crash
+   are reconciled through a downstream idempotency key or status lookup. The
+   filesystem alone cannot provide exactly-once execution for external effects.
 
 Polling must be a pure read with no side effects, so a nervous caller can check
 as often as it likes.
@@ -109,8 +126,15 @@ lifetime domains** and the work must happen on specific hardware:
 - Agents whose runtime imposes a short request timeout but whose tasks do not
 - Any case where opening an inbound port on a developer machine is unacceptable
 
-Prerequisites: a directory both sides can reach, atomic file writes (write to a
-temp name, then rename), and a whitelist on the host defining what may run.
+Prerequisites: a persistent directory both sides can reach, atomic file writes
+(write to a temporary name, flush, then rename), a durable idempotency ledger,
+and a whitelist on the host defining fixed operations and typed arguments.
+
+Authenticate each request with a signature or MAC. Enforce restrictive
+ownership and permissions, reject symlinks and path traversal, run the daemon
+with least privilege, and audit claims, execution, and results. For operations
+that cannot accept an idempotency key or report prior status, surface an
+`uncertain` result for human reconciliation instead of retrying automatically.
 
 Because the host executes real commands, pair the transport with a per-task
 safety envelope — a spend ceiling, a permission scope (read-only versus
@@ -120,16 +144,21 @@ gives durability; it gives no safety on its own.
 ## Trade-offs
 
 - **Pros:**
-  - Survives reboots, sandbox suspension, and caller death without losing work
+  - On a persistent spool, survives sandbox suspension and caller death; with a
+    durable ledger and recovery, it can also survive host restarts
   - No inbound port, no tunnel, no NAT traversal
   - Trivially debuggable and auditable — the protocol is files you can read
-  - Retries are safe when keyed
+  - Completed work is safely replayed, while uncertain work is reconciled
 - **Cons:**
   - Polling adds latency; unsuitable for tight interactive loops
   - Requires a shared mount, which not every sandbox offers
   - The daemon holds real execution authority, so the whitelist and permission
     scope become the security boundary
+  - A shared directory is an inbound control surface and requires request
+    authentication, restrictive permissions, and path-safety checks
   - Concurrent writers need atomic rename discipline or results interleave
+  - Exactly-once external effects require downstream deduplication or
+    reconciliation; the filesystem cannot guarantee them by itself
   - Spool directories grow and need reaping
 
 ## References


### PR DESCRIPTION
Adds a pattern for a problem I didn't find covered in the existing 181: an agent inside a sandbox needs work done on a specific *host* machine, and the two sides have different lifetimes.

**The generalized pattern.** Replace the connection between sandbox and host with a shared spool directory (`queue/`, `results/`, `inbox/`). A host-side daemon watches the queue, executes against a whitelist, and writes results back keyed by task id. The sandbox writes a request and polls whenever it happens to be alive.

Three properties are what make it worth writing down:

1. **No inbound listener** — the host opens no port, so NAT and VPNs stop mattering and the shape isn't a remote-access backdoor.
2. **Caller lifetime is decoupled from work lifetime** — a request survives the sandbox being suspended or reaped, and a 20-minute build isn't orphaned when its caller dies.
3. **Idempotency keys make retries safe** — a caller that can't tell whether its request landed rewrites it with the same key rather than re-running a deploy.

It's essentially the Maildir/mail-spool durability trick applied to agent RPC, which is why I've graded the evidence `medium` rather than higher — the underlying mechanism is long-proven, but I know of no published comparison against tunnel- or socket-based host bridges, and I've said so in the Evidence section.

**Checks run before submitting:**
- `scripts/pattern_validator.py` → 0 issues (negative-controlled: breaking the category and a section header does make it report)
- `scripts/pattern_similarity_checker.py` → no pattern ≥ 0.5 similarity against all 181
- Nearest neighbours (`custom-sandboxed-background-agent`, `lane-based-execution-queueing`, `sandboxed-tool-authorization`) all sit on the other side of the boundary — they isolate work *into* a sandbox; this one reaches *out* to hardware you own.

**Disclosures, per `CONTRIBUTING.md` and `AI_POLICY.md`:**
- The implementation in `source`/References is my own project, declared in `authors`. I've kept it to the Known-Implementations role and added non-self references (Maildir, LangGraph HITL) as the policy asks.
- AI-assisted (Claude Code) for drafting and schema compliance. I've reviewed it and can defend the content — happy to take change requests on framing, category, or status.

If you'd rather the self-referenced implementation link be dropped entirely and the pattern stand on the neutral references alone, say the word and I'll cut it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
