### PR TITLE
fix(web): search results link to /client/* and 404 in production

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build && pagefind --site dist && mkdir -p .vercel/output/static && rm -rf .vercel/output/static/pagefind && cp -R dist/pagefind .vercel/output/static/pagefind",
+    "build": "astro build && pagefind --site dist/client && mkdir -p .vercel/output/static && rm -rf .vercel/output/static/pagefind && cp -R dist/client/pagefind .vercel/output/static/pagefind",
     "preview": "astro preview",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
> Bug fix, not a pattern submission — the pattern-oriented items in the PR template do not apply, so this description follows a problem/fix/verification format instead.

## Problem

Every Pagefind search result links to a `/client/...` URL, which 404s on the deployed site.

`apps/web/astro.config.mjs` uses `@astrojs/vercel`, so `astro build` emits the static HTML into `dist/client/`. The build script in `apps/web/package.json` then ran:

```
pagefind --site dist
```

Pagefind therefore treats `dist/` as the site root and prefixes every indexed url with `/client`. Pagefind's own output makes this visible:

```
Found 191 files matching **/*.{html}
  * "/client/packs/" has no <html> element
```

And in the generated index fragments:

```json
{"url":"/client/patterns/workflow-evals-with-mocked-tools/", ...}
```

`apps/web/src/components/Header.astro` consumes `result.data().url` verbatim in two places, so both the click path and the keyboard path are broken:

- line 285 — `href="${data.url}"` on the rendered result anchor
- line 352 — `window.location.href = currentResults[selectedIndex].url` on Enter

## Fix

Point Pagefind at the actual site root and copy the generated bundle from there:

```diff
-"build": "astro build && pagefind --site dist && ... && cp -R dist/pagefind .vercel/output/static/pagefind",
+"build": "astro build && pagefind --site dist/client && ... && cp -R dist/client/pagefind .vercel/output/static/pagefind",
```

## Verification

Clean build (`rm -rf dist .vercel/output/static/pagefind && npm run build`):

| | before | after |
|---|---|---|
| fragment url | `/client/patterns/discrete-phase-separation/` | `/patterns/discrete-phase-separation/` |
| indexed pages | 189 | 189 |
| `.vercel/output/static/pagefind` | populated | populated |

https://github.com/user-attachments/assets/c2350058-6007-469e-a73e-b267e4f7c5ec

Indexed page count and word count (10781) are identical, so this only changes the URL prefix — no coverage regression. The `has no <html> element` warning for `/client/packs/` is unrelated to this fix and still present as `/packs/`.

No changes to `patterns/`, the README auto-generated sections, or any content files.