### PR TITLE
Add: authenticated-authority-channel

### DIFF
--- a/patterns/authenticated-authority-channel.md
+++ b/patterns/authenticated-authority-channel.md
@@ -1,0 +1,90 @@
+---
+title: Authenticated Authority Channel
+status: emerging
+authors: ["Austin Bell (@robertaustinbell)"]
+based_on: ["CaMeL control/data-flow separation", "Design Patterns for Securing LLM Agents against Prompt Injections"]
+category: Security & Safety
+source: "https://arxiv.org/abs/2503.18813"
+tags: [prompt-injection, authorization, provenance, control-plane, tool-use]
+summary: Preserve a distinguishable channel for authenticated intent so retrieved content can inform reasoning without granting itself authority.
+maturity: early
+complexity: medium
+effort: days
+impact: medium
+signals:
+  - "Agents reason over web pages, files, messages, or tool output while retaining consequential tools"
+  - "Context is summarized, compacted, delegated, or persisted across execution steps"
+  - "A source can contain imperative language that resembles an operator command"
+anti_signals:
+  - "The agent is read-only and cannot access sensitive data, mutate state, or communicate externally"
+  - "A finite action-selector can exclude untrusted content from the control loop entirely"
+prerequisites:
+  - "An authenticated source for current operator intent"
+  - "Runtime-enforced permissions and an execution validation point"
+  - "Provenance labels that survive context construction and handoffs"
+related: ["action-selector-pattern", "policy-gated-tool-proxy", "context-minimization-pattern", "sandboxed-tool-authorization", "lethal-trifecta-threat-model"]
+domains: ["ops", "research", "coding"]
+updated_at: "2026-08-08"
+---
+
+## Problem
+
+Tool-using agents often place operator instructions, standing policy, retrieved documents, webpages, messages, tool output, summaries, and delegated reports in the same model context. Untrusted content can then contain imperative language that resembles a legitimate command. If the runtime does not preserve where each instruction-like statement came from, source content can be mistaken for authorization, persisted as policy, or used to redirect a consequential action.
+
+This is broader than deciding whether a passage is malicious. A benign document can describe a real procedure without authorizing the agent to perform it. The missing distinction is between information that may influence reasoning and input that may grant authority.
+
+## Solution
+
+Maintain a distinguishable **authority channel** throughout the workflow:
+
+- **Control state** contains authenticated current operator intent, explicitly adopted standing policy, and runtime-enforced permissions.
+- **Attributed content** contains external sources, retrieved files, messages under analysis, tool output, model-generated summaries, and delegated reports.
+- Attributed content may supply facts and candidate parameters, but it cannot expand scope, grant permission, alter persistent policy, or authorize execution.
+- A privileged execution point independently validates the proposed operation, target, destination, authority, and arguments against control state before acting.
+- Summarization, compaction, delegation, and persistence must preserve the distinction. If provenance is lost, downgrade to read-only work or request fresh authenticated approval before consequential execution.
+
+```pseudo
+control = load_authenticated_intent_and_policy()
+content = retrieve_with_provenance()
+proposal = reason_over(control.task, content)
+
+if proposal.exceeds(control.authority):
+    request_authenticated_approval(proposal)
+else:
+    executor.validate_and_run(proposal, control, content.provenance)
+```
+
+Labels and prompt delimiters can help the model interpret context, but they are not security boundaries. Back the pattern with scoped credentials, capability controls, egress restrictions, deterministic validation, or isolation proportionate to the downside.
+
+This pattern complements narrower controls in the catalog. Action Selector removes untrusted feedback from a finite control loop; Policy-Gated Tool Proxy and Sandboxed Tool Authorization enforce permissions at the tool boundary; Context Minimization removes tainted material when it is no longer needed; and the Lethal Trifecta reduces dangerous capability combinations. Authenticated Authority Channel instead preserves the authority-versus-content distinction end to end when untrusted material must remain available through retrieval, summarization, compaction, delegation, persistence, and execution.
+
+## Evidence
+
+- **Evidence Grade:** `mixed`
+- **Most Valuable Findings:**
+  - OWASP documents indirect prompt injection through external content and recommends segregating and clearly identifying untrusted content.
+  - CaMeL provides effectiveness evidence for a stronger, narrower architecture that separates trusted control flow from untrusted data and enforces capability policies at tool calls.
+- **Unverified / Unclear:** The cited research does not directly validate this broader end-to-end pattern across retrieval, summarization, compaction, delegation, and persistence. Prompt-level labels alone have not been shown to provide reliable containment, so the behavioral version should not be described as prompt-injection resistance unless the runtime also enforces the boundary.
+
+## How to use it
+
+1. Define which authenticated channel can supply current operator intent. Do not infer authority merely from access to a file, inbox, repository, or tool result.
+2. Attach source type and provenance before external material enters model context. Preserve those labels in summaries and handoffs.
+3. Keep retrieved imperatives attributed to their source. Do not automatically promote them into memory, recurring jobs, configuration, policy, or identity.
+4. Derive candidate actions from the authenticated task while treating source content as evidence and proposed parameters.
+5. At execution time, validate the operation, recipient or target, destination, arguments, scope, and effective permissions independently of free-form source text.
+6. If the runtime cannot reconstruct the authority boundary after compaction or delegation, stop consequential execution, continue read-only analysis, or obtain fresh approval.
+7. Test with matched cases: benign content, a legitimate task-relevant procedure, and an adversarial variant that claims approval or redirects a consequential argument.
+
+## Trade-offs
+
+- **Pros:** Reduces accidental authority laundering; supports flexible reasoning over untrusted content; creates a clear enforcement and audit point; applies where a strict finite action selector is impractical.
+- **Cons:** Requires authenticated intent, provenance-aware context construction, and an independent execution check; labels consume context and may be lost by unsupported runtimes; approval fallbacks can add friction.
+- **Limit:** Provenance establishes attribution, not authenticity or authorization. Control state can be stale, compromised, or bound to the wrong principal. This pattern reduces authority laundering; it does not make an LLM trustworthy, sanitize malicious data, prove source authenticity, or replace technical isolation.
+
+## References
+
+- [OWASP LLM Prompt Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html)
+- Debenedetti et al., [*Defeating Prompt Injections by Design*](https://arxiv.org/abs/2503.18813) — control/data-flow separation and capability enforcement in CaMeL.
+- Beurer-Kellner et al., [*Design Patterns for Securing LLM Agents against Prompt Injections*](https://arxiv.org/abs/2506.08837)
+- [Bobert Agent Template — Untrusted-content execution boundary](https://github.com/robertaustinbell/bobert-agent-template/blob/41f498c3b1292192b7393890940dae9aa1950bd6/RUNTIMES.md#untrusted-content-execution-boundary) — author-maintained documented reference design, not evidence of runtime enforcement.


### PR DESCRIPTION
## PR intent

- [x] Adds a reusable, generalized pattern (not a product announcement).
- [x] One pattern per PR.

## Summary

Adds the **Authenticated Authority Channel** pattern for tool-using agents that must reason over untrusted content without treating that content as operator authority.

The pattern:

- separates authenticated control state from attributed content;
- preserves provenance through retrieval, summarization, compaction, delegation, and persistence;
- requires an independent execution check against authenticated intent and runtime permissions;
- explicitly states that prompt labels and delimiters are not security boundaries;
- positions the pattern as complementary to the existing Action-Selector and Lethal Trifecta patterns.

## Reviewer checklist

- [x] Problem, Solution, and Trade-offs are clearly documented.
- [x] No marketing language or calls to action in the PR description or diff content.
- [x] The pattern is not tied to a single brand as its primary value proposition.
- [x] Public references are included; CaMeL is the primary source and the catalog entry includes OWASP and a second research paper.
- [x] Conflict-of-interest disclosures are included below.

## Verification

- Targeted schema validation passed.
- Targeted content validation passed.
- `git diff --check` passed.
- All four cited URLs returned HTTP 200.
- The data-generation script completed successfully. Generated site artifacts were intentionally excluded because pattern Markdown is the documented source of truth and regeneration currently rewrites unrelated stale artifacts.
- The repository-wide validator currently reports nine pre-existing `effort` metadata errors on the upstream `main` baseline; the new pattern is not among them.
- Two independent reviews checked source support, novelty, overlap, and promotional risk. Their blockers were resolved by making CaMeL the primary source, reducing Bobert to one accurately labeled reference-design citation, narrowing the evidence claim, and explicitly distinguishing five adjacent catalog patterns.

## Conflict-of-interest disclosure

I maintain the Bobert Agent Template linked once in References. It is explicitly labeled as an author-maintained documented reference design, not evidence of runtime enforcement. CaMeL is the primary source, and the pattern remains generalized and independently supported by OWASP guidance and the cited secure-agent design-pattern paper.

## AI-assistance disclosure

Bobert, running GPT-5.6-sol through OpenAI Codex, materially assisted with repository comparison, source research, drafting, schema checks, and adversarial review. Austin Bell reviewed the final pattern, verified the disclosures and references, and approved submission. Austin remains responsible for the contribution and review responses.
