### PR TITLE
Add: persistent-test-memory-feedback-loop

### DIFF
--- a/patterns/persistent-test-memory-feedback-loop.md
+++ b/patterns/persistent-test-memory-feedback-loop.md
@@ -1,0 +1,130 @@
+---
+title: Persistent Test Memory Feedback Loop
+status: emerging
+authors:
+  - Pranshu Chittora (@pranshuchittora)
+based_on:
+  - Vostride Agent QA (contributor-affiliated implementation)
+  - Shinn et al. (Reflexion)
+category: Learning & Adaptation
+source: https://github.com/vostride/agent-qa
+tags:
+  - testing-agents
+  - persistent-memory
+  - feedback-loop
+  - self-healing
+  - regression-testing
+summary: Preserve validated test lessons so an agent can reuse successful paths, recognize recurring failures, and retire stale knowledge.
+maturity: early
+complexity: medium
+effort: days
+impact: medium
+signals:
+  - Repeated user-flow tests against an evolving interface
+  - The agent repeatedly rediscovers the same navigation or failure cause
+anti_signals:
+  - Stateless one-off checks
+  - Tests whose state or evidence cannot be stored safely
+prerequisites:
+  - A stable scope key for application and environment
+  - Structured run evidence and a pass/fail oracle
+related:
+  - memory-synthesis-from-execution-logs
+  - rich-feedback-loops
+  - workflow-evals-with-mocked-tools
+tools:
+  - test-runner
+  - memory-store
+  - evidence-recorder
+domains:
+  - software-testing
+  - web
+  - mobile
+updated_at: '2026-08-16'
+---
+
+## Problem
+
+An agent that executes end-to-end tests without durable memory starts each run from
+scratch. It repeatedly rediscovers navigation paths, semantic landmarks, and known
+failure causes. When an interface changes, brittle replay can fail even though the
+user intent is unchanged.
+
+Saving every trace is not enough. Raw traces contain transient state, sensitive
+values, and accidental successes. Replaying them uncritically turns old evidence
+into a new source of test flakiness.
+
+## Solution
+
+Place a scoped, evidence-gated memory loop around the test executor:
+
+1. **Scope retrieval** by application, environment, test intent, and identity
+   boundary. Retrieve a small set of relevant, recently verified records.
+2. **Intent-preserving execution** uses remembered semantic landmarks and prior
+   failure classifications as hints, not as a fixed action script.
+3. **Structured observation** records actions, assertions, screenshots or logs,
+   failure signatures, and the final oracle result.
+4. **Write gating** promotes a lesson only when evidence supports it. Redact
+   secrets and reject run-specific values such as session IDs or timestamps.
+5. **Correction and decay** lower confidence, supersede, or retire a record when a
+   later run contradicts it.
+
+A memory record should carry provenance rather than only a prose hint:
+
+    scope: app + environment + test-intent
+    claim: Checkout opens from the cart summary
+    confidence: 0.82
+    evidence: run-id-184
+    last_verified: 2026-08-16
+    failure_signature: null
+    supersedes: memory-id-27
+
+The key distinction from general log synthesis is that retrieval sits directly in
+the execution path, while every write is tied to a test oracle and can be reversed
+by contradictory evidence.
+
+## How to use it
+
+- Start with one repeated, non-destructive user flow and define its scope key.
+- Store artifacts separately from compact memories; keep links from each memory to
+  the evidence that justified it.
+- Prefer semantic facts such as labels, roles, and navigation relationships over
+  copied DOM paths or screen coordinates.
+- Require more than one confirmation before promoting risky or broadly scoped
+  lessons. Apply shorter expiry to volatile interfaces.
+- Treat a remembered path as a ranked hint. The executor must still observe the
+  current interface and satisfy the current assertion.
+- Make correction first-class: a failed remembered step should produce a proposed
+  replacement or confidence reduction, not an endless retry.
+- Redact credentials, personal data, tokens, and test fixtures before persistence.
+  Separate memory by tenant and environment.
+- Keep human approval around production writes, purchases, deletion, and other
+  high-impact actions even when a path has succeeded before.
+
+Use the loop for regression suites where the same intent is exercised many times
+against a changing application. Pair it with mocked workflow evals when the agent
+itself must be tested without touching a live system.
+
+## Trade-offs
+
+**Pros:**
+
+- Reduces repeated exploration across runs.
+- Lets tests survive some interface changes without discarding the original intent.
+- Preserves evidence and provenance for debugging.
+- Converts recurring failures into reusable, scoped knowledge.
+
+**Cons:**
+
+- Stale or falsely promoted memories can systematically mislead later runs.
+- Safe isolation, redaction, retention, and invalidation add operational complexity.
+- Retrieval and write gating increase latency and storage cost.
+- Adaptation can hide product regressions unless the assertion oracle remains
+  independent from the learned navigation path.
+
+## References
+
+- [Reflexion: Language Agents with Verbal Reinforcement Learning](https://arxiv.org/abs/2303.11366) — episodic feedback and memory for later decisions.
+- [Memory Synthesis from Execution Logs](memory-synthesis-from-execution-logs.md) — related batch synthesis of reusable lessons.
+- [Workflow Evals with Mocked Tools](workflow-evals-with-mocked-tools.md) — related safe validation of complete agent workflows.
+- [Vostride Agent QA](https://github.com/vostride/agent-qa) — contributor-affiliated implementation of persistent memory in a software-testing agent.


### PR DESCRIPTION
## PR intent

- [x] Adds a reusable, generalized pattern (not a product announcement).
- [x] One pattern per PR.

## Reviewer checklist

- [x] Problem, Solution, and Trade-offs are clearly documented.
- [x] No marketing language or calls to action in the PR description or diff content.
- [x] The pattern is not tied to a single brand as its primary value proposition.
- [x] Public references are included; the contributor-affiliated implementation is supplemented by the non-affiliated Reflexion paper and related catalog patterns.
- [x] Conflict-of-interest disclosures are included where applicable.

## Pattern summary

**Persistent Test Memory Feedback Loop** describes how a testing agent can retrieve scoped lessons before a run, collect structured evidence, gate memory writes through an independent test oracle, and later supersede or retire contradicted knowledge.

The safety boundary is deliberate: remembered paths are ranked hints, not assertions, and production writes or other high-impact actions retain human approval.

## Novelty and differentiation

- Unlike **Memory Synthesis from Execution Logs**, retrieval is in the repeated test-execution path and every write is reversible, scoped, and tied to an oracle.
- Unlike **Workflow Evals with Mocked Tools**, this pattern addresses durable learning across regression runs against an evolving application.
- The pattern specifies provenance, confidence, expiry, correction, tenant/environment isolation, and secret redaction.

## Disclosure

Agent QA is a contributor-affiliated implementation. That relationship is stated in based_on and the reference annotation. The product is only an implementation example; the pattern is written generically and cites Reflexion plus related non-affiliated catalog entries.

## Validation

- TypeScript schema validator passes for the new file
- TypeScript content validator passes for the new file
- strict Python validator: 0 issues
- similarity checker: no existing pattern at or above the 0.5 threshold
- bun run build:data completes successfully

The repository-wide schema commands currently surface existing invalid effort values in unrelated patterns; the new file passes both validators in isolation.
