### PR TITLE
Fix effort schema and pattern reviewer checkout

### DIFF
--- a/.github/workflows/pattern-reviewer.yml
+++ b/.github/workflows/pattern-reviewer.yml
@@ -20,6 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Checkout base repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
       - name: Review PR against project contribution principles
         uses: anthropics/claude-code-action@5ef2e550a465a721f4f45e4a7d3c340c873e1dcc # v1
         with:

--- a/apps/web/src/content.config.ts
+++ b/apps/web/src/content.config.ts
@@ -25,7 +25,7 @@ const patternCategory = z.enum([
 
 const patternMaturity = z.enum(['early', 'maturing', 'mature']);
 const patternComplexity = z.enum(['low', 'medium', 'high', 'very-high']);
-const patternEffort = z.enum(['low', 'medium', 'high', 'very-high']);
+const patternEffort = z.enum(['hours', 'days', 'weeks']);
 const patternImpact = z.enum(['low', 'medium', 'high', 'transformative']);
 
 // Patterns live in the monorepo root `patterns/` directory. Point Astro's

--- a/patterns/agent-circuit-breaker.md
+++ b/patterns/agent-circuit-breaker.md
@@ -9,7 +9,7 @@ tags: [circuit-breaker, fault-tolerance, tool-reliability, graceful-degradation,
 summary: "Prevents agents from wasting tokens and time on repeatedly failing tools by tracking failure rates and temporarily disabling broken tool endpoints"
 maturity: "maturing"
 complexity: "medium"
-effort: low
+effort: hours
 impact: "high"
 signals: ["Agent calls external APIs or tools that can fail", "Retries burn tokens without progress", "Multiple tool providers available for fallback"]
 anti_signals: ["All tools are local and deterministic", "Single-shot agent with no retry logic"]

--- a/patterns/board-mediated-inter-agent-coordination.md
+++ b/patterns/board-mediated-inter-agent-coordination.md
@@ -24,7 +24,7 @@ related:
   - cross-cycle-consensus-relay
   - memory-synthesis-from-execution-logs
 complexity: medium
-effort: medium
+effort: days
 impact: high
 ---
 

--- a/patterns/commitment-ledger-reality-gated-credit.md
+++ b/patterns/commitment-ledger-reality-gated-credit.md
@@ -9,7 +9,7 @@ tags: [commitment-ledger, outcome-feedback, agent-memory, credit-assignment, rea
 summary: "Records agent promises and credits retrieved memory only after an externally verifiable outcome settles."
 maturity: early
 complexity: medium
-effort: medium
+effort: days
 impact: high
 signals: ["Multi-step agent work", "Clear success or failure signal", "Need auditable learning history"]
 anti_signals: ["One-shot answers", "No observable outcome", "Highly sensitive data without retention policy"]

--- a/patterns/denial-tracking-permission-escalation.md
+++ b/patterns/denial-tracking-permission-escalation.md
@@ -19,7 +19,7 @@ summary: >-
   fallback strategies, preventing wasted iterations in non-interactive contexts.
 maturity: maturing
 complexity: low
-effort: low
+effort: hours
 impact: high
 signals:
   - "Agent runs in non-interactive or background mode"

--- a/patterns/local-first-credential-broker.md
+++ b/patterns/local-first-credential-broker.md
@@ -7,7 +7,7 @@ source: "https://cloudsecurityalliance.org/artifacts/agentic-ai-identity-and-acc
 tags: [credentials, oauth, api-keys, proxy, local-first, agent-identity]
 summary: "Keep raw secrets out of the agent process by injecting credentials at the network layer through a local broker, rather than handing the agent environment variables or config files."
 complexity: medium
-effort: medium
+effort: days
 impact: high
 signals:
   - "Agents call multiple authenticated SaaS APIs in one run"

--- a/patterns/markdown-polis-coordination.md
+++ b/patterns/markdown-polis-coordination.md
@@ -8,7 +8,7 @@ source: "https://github.com/yehudalevy-collab/polis-protocol"
 tags: [multi-agent, coordination, markdown, bandit-routing, governance, vendor-agnostic]
 maturity: maturing
 complexity: medium
-effort: medium
+effort: days
 impact: high
 signals: ["Multiple agents from different vendors need to share state on the same project", "Routing decisions should improve from past outcomes, not just static capability declarations", "Process rules need to evolve without breaking running work"]
 anti_signals: ["Single-agent solo session", "Pure RPC between two agents with no shared state", "Hard real-time coordination (sub-second latency requirements)"]

--- a/patterns/orchestration-prompt-writing-benchmark.md
+++ b/patterns/orchestration-prompt-writing-benchmark.md
@@ -9,7 +9,7 @@ tags: [multi-agent, orchestration, benchmark, evaluation, prompt-engineering, ro
 summary: "Score an orchestrator LLM on whether it assigns the right information fragments to the right sub-agent roles and writes correct sub-agent prompts, independent of whether the downstream task happens to succeed anyway."
 maturity: "early"
 complexity: "medium"
-effort: medium
+effort: days
 impact: "medium"
 signals: ["Building a multi-agent system with a fixed or evolving communication topology", "Orchestrator failures are hard to attribute to a specific sub-agent vs. a bad hand-off prompt", "You already have end-to-end evals but still see silent quality regressions"]
 anti_signals: ["Single-agent system with no delegation", "Topology is trivial (one sub-agent, one round-trip)"]

--- a/patterns/output-verification-loop.md
+++ b/patterns/output-verification-loop.md
@@ -16,7 +16,7 @@ summary: >-
   evidence sources, and returning per-claim trust scores before acting on
   the result.
 complexity: low
-effort: low
+effort: hours
 impact: high
 signals: ["Agent output feeds into decisions or downstream agents", "Hallucination risk is non-trivial", "Compliance requires an audit trail"]
 anti_signals: ["Output is purely creative with no factual claims", "Latency budget under 500ms"]

--- a/patterns/unified-tool-gateway.md
+++ b/patterns/unified-tool-gateway.md
@@ -10,7 +10,7 @@ summary: "Route all agent tool calls through a single gateway that handles disco
 slug: "unified-tool-gateway"
 maturity: "maturing"
 complexity: "medium"
-effort: medium
+effort: days
 impact: "high"
 signals: ["Agent needs 10+ external tools or APIs", "Managing multiple API keys across providers", "Usage-based billing required across tools", "Teams sharing tool access with centralized controls"]
 anti_signals: ["Single-provider tool usage", "Agents that only need 1-2 tools", "Fully offline or air-gapped environments"]


### PR DESCRIPTION
## Summary

- align Astro effort validation with the documented `hours | days | weeks` schema
- migrate existing level-based effort metadata back to duration values
- checkout the trusted PR base SHA before running the Pattern Reviewer action
- disable persisted checkout credentials in the review job

## Verification

- `bun run validate:patterns` passes
- `bun run build` passes
- `bun run validate:patterns:content` still reports the pre-existing missing References section in `cross-agent-lesson-sharing.md`