### PR TITLE
Fix Pattern Reviewer API endpoint

### DIFF
--- a/.github/workflows/pattern-reviewer.yml
+++ b/.github/workflows/pattern-reviewer.yml
@@ -27,7 +27,11 @@ jobs:
           persist-credentials: false
 
       - name: Review PR against project contribution principles
-        uses: anthropics/claude-code-action@5ef2e550a465a721f4f45e4a7d3c340c873e1dcc # v1
+        uses: anthropics/claude-code-action@3f854a8fb5146b39d5cbf8b57f70d80810e1366f # v1
+        env:
+          # The repository API key is issued for this Anthropic-compatible
+          # endpoint. The action reads custom endpoints from the caller env.
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL || vars.ANTHROPIC_BASE_URL }}
         with:
           github_token: ${{ github.token }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY || vars.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

- pass the repository configured `ANTHROPIC_BASE_URL` to Claude Code Action
- update the action pin to the current audited v1 commit
- preserve the trusted-base checkout, external-contributor guard, and least-privilege permissions

## Root cause

The API key and custom base URL are configured together as repository secrets, but only the key reached the action. Claude Code therefore initialized and then failed its first request with the opaque one-turn, zero-cost `is_error:true` result tracked in #137.

## Validation

- workflow YAML parses successfully
- `git diff --check` passes
- action input behavior verified against the pinned upstream `action.yml`, which reads `ANTHROPIC_BASE_URL` from the caller environment

A controlled pattern-review PR will exercise the live invocation immediately after merge.

Fixes #137